### PR TITLE
build(deps): bump version of jackson-databind.version from 2.9.9 to 2…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <properties>
         <groovy.version>2.5.7</groovy.version>
         <httpclient.version>4.5.8</httpclient.version>
-        <jackson-databind.version>2.9.9</jackson-databind.version>
+        <jackson-databind.version>2.9.10.1</jackson-databind.version>
 
         <gmavenplus-plugin.version>1.7.1</gmavenplus-plugin.version>
         <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>


### PR DESCRIPTION
CVE-2019-17531
critical severity
Vulnerable versions: < 2.9.10.1
Patched version: 2.9.10.1
A Polymorphic Typing issue was discovered in FasterXML jackson-databind 2.0.0 through 2.9.10. When Default Typing is enabled (either globally or for a specific property) for an externally exposed JSON endpoint and the service has the apache-log4j-extra (version 1.2.x) jar in the classpath, and an attacker can provide a JNDI service to access, it is possible to make the service execute a malicious payload.