### PR TITLE
Migrate from adopt to temurin

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           java-version: 17
-          distribution: adopt
+          distribution: temurin
           cache: maven
       - run: mvn verify


### PR DESCRIPTION
AdoptOpenJDK is deprecated, see https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/